### PR TITLE
fix maven jar plugin version

### DIFF
--- a/hotmoka-and-takamaka-assembly/pom.xml
+++ b/hotmoka-and-takamaka-assembly/pom.xml
@@ -31,7 +31,7 @@
   <plugin>
     <groupId>org.apache.maven.plugins</groupId>
     <artifactId>maven-jar-plugin</artifactId>
-    <version>3.3.0</version>
+    <version>3.2.0</version>
     <executions>
         <execution>
             <id>default-jar</id>


### PR DESCRIPTION
Buongiorno prof,

Le mando un pull request per fixare la versione del plugin maven jar presente nel module hotmoka-and-takamaka-assembly.
Se lei guarda su maven central, non esiste la versione 3.3.0 e quindi il progetto non mi compilava. 
Come soluzione ho aggiornato la versione alla 3.2.0 presente su maven central.

Cordiali saluti, 
  Dinu